### PR TITLE
Fix negative scale

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,10 +13,13 @@ examples/
 .*swm
 
 #libraries
-hdf5-1.8.14/
+hdf5-*/
+hdf5-*.tar.gz
 tensorflow/
-hdf5-1.8.14.tar.gz
 htslib/
+fast5/
+htslib/
+tinydir/
 
 #generated
 .depend

--- a/Makefile
+++ b/Makefile
@@ -20,14 +20,18 @@ ifeq ($(zstd),1)
 endif
 
 #hdf5
-H5_LIB = ./hdf5-1.8.14/hdf5/lib/libhdf5.a
-H5_INCLUDE = -I./hdf5-1.8.14/hdf5/include
+H5_VER_MAJOR = 1.10
+H5_VER_MINOR = 8
+H5_VER = $(H5_VER_MAJOR).$(H5_VER_MINOR)
+H5_LIB = ./hdf5-$(H5_VER)/hdf5/lib/libhdf5.a
+H5_INCLUDE = -I./hdf5-$(H5_VER)/hdf5/include
 
 #hts
 HTS_LIB = ./htslib/libhts.a
 HTS_INCLUDE = -I./htslib
 
 #tensorflow
+TENS_NAME = "libtensorflow-gpu-linux-x86_64-2.10.0.tar.gz"
 TENS_DEPEND = tensorflow/include/tensorflow/c/c_api.h
 TENS_LIB = -Wl,-rpath,${PATH_SPACEFIX}tensorflow/lib -L tensorflow/lib
 TENS_INCLUDE = -I./tensorflow/include
@@ -47,12 +51,12 @@ all: depend $(MAIN_EXECUTABLE)
 htslib/libhts.a:
 	cd htslib && make && cd .. || exit 255
 
-hdf5-1.8.14/hdf5/lib/libhdf5.a:
-	if [ ! -e hdf5-1.8.14/hdf5/lib/libhdf5.a ]; then \
-		wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8/hdf5-1.8.14/src/hdf5-1.8.14.tar.gz; \
-		tar -xzf hdf5-1.8.14.tar.gz || exit 255; \
-		cd hdf5-1.8.14 && \
-			./configure --enable-threadsafe && \
+hdf5-$(H5_VER)/hdf5/lib/libhdf5.a:
+	if [ ! -e hdf5-$(H5_VER)/hdf5/lib/libhdf5.a ]; then \
+		wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-$(H5_VER_MAJOR)/hdf5-$(H5_VER)/src/hdf5-$(H5_VER).tar.gz; \
+		tar -xzf hdf5-$(H5_VER).tar.gz || exit 255; \
+		cd hdf5-$(H5_VER) && \
+			./configure --enable-threadsafe --enable-unsupported && \
 			make && make install; \
 	fi 
 
@@ -60,8 +64,8 @@ tensorflow/include/tensorflow/c/c_api.h:
 	if [ ! -e tensorflow/include/tensorflow/c/c_api.h ]; then \
 		mkdir tensorflow; \
 		cd tensorflow; \
-		wget https://storage.googleapis.com/tensorflow/libtensorflow/libtensorflow-gpu-linux-x86_64-2.4.1.tar.gz; \
-		tar -xzf libtensorflow-gpu-linux-x86_64-2.4.1.tar.gz || exit 255; \
+		wget https://storage.googleapis.com/tensorflow/libtensorflow/$(TENS_NAME); \
+		tar -xzf $(TENS_NAME) || exit 255; \
 		cd ..; \
 	fi 
 	

--- a/src/alignment.cpp
+++ b/src/alignment.cpp
@@ -1533,7 +1533,10 @@ std::cerr << "Out of reference sequence size: " << (r.referenceSeqMappedTo).leng
 			double scaledEvent = (eventSnippet[evIdx] - r.scalings.shift) / r.scalings.scale;
 			double eventLength = eventLengthsSnippet[evIdx];
 
-			assert(scaledEvent > 0.0);
+			if (!(scaledEvent > 0.0)) {
+                                std::cout << "Bad scaledEvent(1) intercepted " << scaledEvent << std::endl;
+                                throw "scaledEvent error(1) in the evenalign_detect ...";
+                        }
 
 			unsigned int evPos;
 			std::string sixMerRef;
@@ -1732,7 +1735,10 @@ std::cerr << "Out of reference sequence size: " << (r.referenceSeqMappedTo).leng
 			double scaledEvent = (eventSnippet[evIdx] - r.scalings.shift) / r.scalings.scale;
 			double eventLength = eventLengthsSnippet[evIdx];
 
-			assert(scaledEvent > 0.0);
+			if (!(scaledEvent > 0.0)) {
+				std::cout << "Bad scaledEvent(2) intercepted " << scaledEvent << std::endl;
+				throw "scaledEvent error(2) in the evenalign_detect ...";
+			}
 
 			unsigned int evPos;
 			std::string sixMerRef;

--- a/src/detect.cpp
+++ b/src/detect.cpp
@@ -1044,14 +1044,21 @@ int detect_main( int argc, char** argv ){
 					prog++;
 					continue;
 				}
-				// catch strange reads with scale < 0.0 - that originate from short alignments
-				if ( r.scalings.scale <= 0.0 ) {
+
+				std::pair<bool,std::shared_ptr<AlignedRead>> ar;
+				try {
+					ar = eventalign_detect( r, windowLength_align, args.dilation );
+				} catch (const char* error_msg) {
+					std::cout << "eventalign_detect threw an error: " << error_msg << std::endl;
+					std::cout << "details about the offending read:" << std::endl;
+					std::cout << r.basecall << " " << r.referenceSeqMappedTo << " " << r.readID << std::endl;
+					std::cout << r.scalings.shift<<" "<<r.scalings.drift<<" "<<r.scalings.scale<<" "<<r.scalings.var;
+					std::cout << std::endl << std::endl;
+					// treating it as a "regular" failed read here ...
 					failed++;
 					prog++;
 					continue;
 				}
-
-				std::pair<bool,std::shared_ptr<AlignedRead>> ar = eventalign_detect( r, windowLength_align, args.dilation );
 
 				if (not ar.first){
 					failed++;

--- a/src/detect.cpp
+++ b/src/detect.cpp
@@ -1044,6 +1044,12 @@ int detect_main( int argc, char** argv ){
 					prog++;
 					continue;
 				}
+				// catch strange reads with scale < 0.0 - that originate from short alignments
+				if ( r.scalings.scale <= 0.0 ) {
+					failed++;
+					prog++;
+					continue;
+				}
 
 				std::pair<bool,std::shared_ptr<AlignedRead>> ar = eventalign_detect( r, windowLength_align, args.dilation );
 


### PR DESCRIPTION
This is just a quick fix for #35 -> simply replaced an `assertion` with error `throw`-ing in `alignment.cpp` and then caught it downstream in the `detect.cpp` - such that `scaledEvent<=0`-alignments contribute to the "failed" pile of reads instead of crashing the program

This isn't the most elegant fix and it doesn't "explain" why `scaledEvent<=0` occur in the first place, however it helped us to avoid restarting the program after and manually filtering "failing" reads/alignments.

I'm not sure if you guys accept PRs and if you're interested in a simple fix like that - please let me know if you do - I can clean up the code and remove irrelevant changes, e.g. in a `Makefile` and `.gitignore`